### PR TITLE
Add overriding HTML content to popup - allows for rich popups

### DIFF
--- a/datasette_cluster_map/static/datasette-cluster-map.js
+++ b/datasette_cluster_map/static/datasette-cluster-map.js
@@ -67,6 +67,11 @@ const clusterMapMarkerContent = (row) => {
                 popup = {};
             }
         }
+        if (popup.html) {
+            // We have received HTML - render that as is
+            // WARNING - does not escape HTML, as a feature.
+            return popup.html
+        }
         if (popup.image || popup.title || popup.description || popup.link) {
             // We have a valid popup configuration - render that
             let html = [];


### PR DESCRIPTION
This feature allows for pure HTML to be defined for popups, which if required ignores any other image/title/description/link metadata. 

Sample [deployment](https://nsw-covid-case-locations-datasette-7vzrs5djoq-uc.a.run.app/data/nsw?_facet=Alert#lng=151.17096;lat=-33.85176;zoom=15) and [usage](https://github.com/glasnt/nsw-covid-case-locations-datasette/blob/latest/preprocess.py#L29-L36)
<img width="607" alt="Screen Shot 2021-01-04 at 10 27 10 am" src="https://user-images.githubusercontent.com/813732/103491377-8e46a000-4e77-11eb-9bfc-2054818c7be3.png">


(Suggested improvements welcome!)