### PR TITLE
Handle cases where columns may have null values

### DIFF
--- a/datasette_cluster_map/static/datasette-cluster-map.js
+++ b/datasette_cluster_map/static/datasette-cluster-map.js
@@ -101,7 +101,6 @@ const clusterMapMarkerContent = (row) => {
     }
     // Otherwise, use a <dl>
     const dl = document.createElement('dl');
-    console.log(row);
     Object.keys(row).forEach(key => {
         const dt = document.createElement('dt');
         dt.appendChild(document.createTextNode(key));
@@ -110,7 +109,7 @@ const clusterMapMarkerContent = (row) => {
         let label = value;
         let extra = null;
         if (typeof value === 'object') {
-            if (value.label !== undefined && value.value !== undefined) {
+            if (value !== null && value.label !== undefined && value.value !== undefined) {
                 label = value.label;
                 extra = document.createElement('span');
                 extra.appendChild(document.createTextNode(' ' + value.value));


### PR DESCRIPTION
Ran into a case where map does not load when column values are null. The error
is triggered since null is of type object which then when we hit line 113 we have null value variable.

![Screen Shot 2021-01-23 at 1 49 38 PM](https://user-images.githubusercontent.com/6503150/105615356-ca896400-5d84-11eb-977d-90da0ebdeeab.png)
